### PR TITLE
First Pass at GHA Runners for Windows & MacOS

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Discord RSS Docker Image
-      run: docker build . -- file Dockerfile --tag discord-rss:automated_build_$(date +%s)
+      run: docker build . --file Dockerfile --tag discord-rss:automated_build_$(date)

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build Docker Image
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,16 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Discord RSS Docker Image
+      run: docker build . -- file Dockerfile --tag discord-rss:automated_build_$(date +%s)

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Discord RSS Docker Image
-      run: docker build . --file Dockerfile --tag discord-rss:automated_build_$(date)
+      run: docker build -t discord-rss:automated_build_$(date +%s) .

--- a/.github/workflows/build-macos12.yaml
+++ b/.github/workflows/build-macos12.yaml
@@ -1,4 +1,4 @@
-name: MacOS Monterey | Build Go Binary
+name: MacOS Monterey
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build Go Binary
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/build-macos12.yaml
+++ b/.github/workflows/build-macos12.yaml
@@ -1,0 +1,21 @@
+name: MacOS Monterey | Build Go Binary
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Up Golang Environment
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    
+    - name: Build Go Binary
+      run: cd discord-rss && go build -v

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 | Build Go Binary
+name: Ubuntu 20.04
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build Go Binary
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -1,0 +1,21 @@
+name: Ubuntu 20.04 | Build Go Binary
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Up Golang Environment
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    
+    - name: Build Go Binary
+      run: cd discord-rss && go build -v

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -1,0 +1,21 @@
+name: Windows Server 2022 | Build Go Binary
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set Up Golang Environment
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    
+    - name: Build Go Binary
+      run: cd discord-rss && go build -v

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -1,4 +1,4 @@
-name: Windows Server 2022 | Build Go Binary
+name: Windows Server 2022
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build Go Binary
     runs-on: windows-2022
 
     steps:


### PR DESCRIPTION
This PR is a part of issue #7 in which I am trying to add automated build tests for different operating systems. Specifically, this PR attempts builds for `windows-2022`, `ubuntu-20.04`, and `macos-12`. Additionally, I've added an action for building the Docker Image for the `discord-rss` application.