### PR TITLE
Dockerfile Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,14 @@ FROM golang:1.16.3-alpine3.13
 WORKDIR /app
 COPY /discord-rss/ .
 RUN go mod download
-ENV BOT_TOKEN="defaultvalue"
-ENV RSS_URL="https://fake_url.com"
-ENV CHANNEL_ID="12345678910"
-ENV TIMER_INT=8
+
+# Discord RSS Set Up | Build Arguments:
+ARG bot_token
+ARG rss_url
+ARG channel_id
+ARG timer_int=8
+ARG username
+ARG password
+
 RUN go build
-CMD ./discord-rss -t $BOT_TOKEN -u $RSS_URL -c $CHANNEL_ID -timer $TIMER_INT
+CMD ./discord-rss -t $bot_token -u $rss_url -c $channel_id -timer $timer_int -user $username -pass $password

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ COPY /discord-rss/ .
 RUN go mod download
 
 # Discord RSS Set Up | Build Arguments:
-ARG bot_token
-ARG rss_url
-ARG channel_id
-ARG timer_int=8
-ARG username
-ARG password
+ENV BOT_TOKEN="defaultvalue"
+ENV RSS_URL="https://fake_url.com"
+ENV CHANNEL_ID="12345678910"
+ENV TIMER_INT=8
+ENV USERNAME=""
+ENV PASSWORD=""
 
 RUN go build
-CMD ./discord-rss -t $bot_token -u $rss_url -c $channel_id -timer $timer_int -user $username -pass $password
+CMD ./discord-rss -t $BOT_TOKEN -u $RSS_URL -c $CHANNEL_ID -timer $TIMER_INT -user $USERNAME -pass $PASSWORD

--- a/discord-rss/main.go
+++ b/discord-rss/main.go
@@ -42,7 +42,7 @@ func init() {
 	flag.StringVar(&Token, "t", "", "Bot Token")
 	flag.StringVar(&Url, "u", "", "RSS Feed URL")
 	flag.StringVar(&ChannelId, "c", "", "Channel ID you want messages to post in")
-	flag.IntVar(&TickerTimer, "timer", 0, "Sets how long the auto parser will run for")
+	flag.IntVar(&TickerTimer, "timer", 0, "Sets how long the auto parser will run for in hours")
 	flag.StringVar(&BasicAuthUsername, "user", "", "Allows you to pass in the 'Username' part of your BasicAuthentication credentials")
 	flag.StringVar(&BasicAuthPassword, "pass", "", "Allows you to pass in the 'Password' part of your BasicAuthentication credentials")
 	flag.Parse()


### PR DESCRIPTION
## Description
Updates the Dockerfile to attempt to use [ARGs](https://docs.docker.com/engine/reference/builder/#arg) instead of [ENVs](https://docs.docker.com/engine/reference/builder/#env) to make the build process a bit more secure. Additionally, this PR adds arguments for the `-user` and `-pass` flags that were added in Commit [`7377955`](https://github.com/jacob-card-howe/discord-rss/commit/7377955d387319edf120c0ff5fc205024653594f)

## Additional Context
* [Commit `7377955`](https://github.com/jacob-card-howe/discord-rss/commit/7377955d387319edf120c0ff5fc205024653594f)
* [Docker ARGs](https://docs.docker.com/engine/reference/builder/#arg)
* [Docker ENVs](https://docs.docker.com/engine/reference/builder/#env)